### PR TITLE
detect outdated and insecure Ruby versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,13 +6,17 @@
 
 Your gem doesn't support all possible Ruby versions.
 
+And not all Ruby versions are secure to even have installed.
+
 So, you need to tell users which Ruby versions you support in:
 
 1. Your gemspec
 2. Your README
 3. Your .travis.yml file
+4. Any issues you get about which version of Ruby is supported or not
 
-That breaks the principle of single responsibility.
+But maintaning that information in 4 different places breaks the principle of
+single responsibility.
 
 
 ## The solution
@@ -23,11 +27,14 @@ It assumes you are using Travis and the versions listed in your `.travis.yml` ar
 
 This helps you limit the Ruby versions you support - just by adding/removing entries in your Travis configuration file.
 
+Also, you it can warn users if they are using an outdated version of Ruby.
+
+(Or one with security vulnerabilities).
 
 
 ## Usage
 
-E.g. in your gemspec file:
+1. E.g. in your gemspec file:
 
 ```ruby
   begin
@@ -40,15 +47,21 @@ E.g. in your gemspec file:
   s.add_development_dependency 'ruby_dep', '~> 1.0'
 ```
 
-In your `README.md`:
+2. In your `README.md`:
 
 Replace your mentions of "supported Ruby versions" to point to the Travis build.
 
 (Or, you can point to the rubygems.org site where the required Ruby version is listed).
 
-If it works on Travis, it's assumed to be supported, right? 
+If it works on Travis, it's assumed to be supported, right?
 
 If it fails, it isn't, right?
+
+3. In your library:
+
+require 'ruby_dep/warnings'
+RubyDep::Warning.show_warnings
+
 
 ## Roadmap
 

--- a/lib/ruby_dep/warning.rb
+++ b/lib/ruby_dep/warning.rb
@@ -1,0 +1,41 @@
+module RubyDep
+  class Warning
+    MSG_BUGGY = 'RubyDep: WARNING: your Ruby is outdated/buggy.'\
+      ' Please upgrade.'.freeze
+
+    MSG_INSECURE = 'RubyDep: WARNING: your Ruby has security vulnerabilities!'\
+      ' Please upgrade!'.freeze
+
+    def show_warnings
+      case check_ruby
+      when :insecure
+        STDERR.puts MSG_INSECURE
+      when :buggy
+        STDERR.puts MSG_BUGGY
+      when :unknown
+      else
+        raise "Unknown problem type: #{problem.inspect}"
+      end
+    end
+
+    private
+
+    VERSION_INFO = {
+      '2.3.1' => :unknown,
+      '2.3.0' => :buggy,
+      '2.2.5' => :unknown,
+      '2.2.4' => :buggy,
+      '2.2.0' => :insecure,
+      '2.1.9' => :buggy,
+      '2.0.0' => :insecure
+    }.freeze
+
+    def check_ruby
+      version = Gem::Version.new(RUBY_VERSION)
+      VERSION_INFO.each do |ruby, status|
+        return status if version >= Gem::Version.new(ruby)
+      end
+      :insecure
+    end
+  end
+end

--- a/spec/lib/ruby_dep/warning_spec.rb
+++ b/spec/lib/ruby_dep/warning_spec.rb
@@ -1,0 +1,45 @@
+require 'ruby_dep/warning'
+
+RSpec.describe RubyDep::Warning do
+  before do
+    allow(STDERR).to receive(:puts)
+    stub_const('RUBY_VERSION', ruby_version)
+  end
+
+  context 'with an up-to-date Ruby' do
+    let(:ruby_version) { '2.3.1' }
+    it '#show_warnings' do
+      expect(STDERR).to_not receive(:puts)
+      subject.show_warnings
+    end
+  end
+
+  context 'with a secure but buggy Ruby' do
+    let(:ruby_version) { '2.2.4' }
+    it '#show_warnings' do
+      expect(STDERR).to receive(:puts).with(
+        'RubyDep: WARNING: your Ruby is outdated/buggy. Please upgrade.')
+      subject.show_warnings
+    end
+  end
+
+  context 'with an insecure Ruby' do
+    let(:ruby_version) { '2.2.3' }
+    it '#show_warnings' do
+      expect(STDERR).to receive(:puts).with(
+        'RubyDep: WARNING: your Ruby has security vulnerabilities!'\
+        ' Please upgrade!')
+      subject.show_warnings
+    end
+  end
+
+  context 'with an unsupported Ruby' do
+    let(:ruby_version) { '1.9.3' }
+    it '#show_warnings' do
+      expect(STDERR).to receive(:puts).with(
+        'RubyDep: WARNING: your Ruby has security vulnerabilities!'\
+        ' Please upgrade!')
+      subject.show_warnings
+    end
+  end
+end


### PR DESCRIPTION
RubyDep::Warning.show_warnings warns if the Ruby version isn't recommended.
