### PR TITLE
Add JRuby dependency and warning support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,4 +2,5 @@ sudo: false
 language: ruby
 rvm:
   - 2.2.4
+  - jruby-9.0.5.0
 before_install: gem install bundler -v 1.12.0.rc.4

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 sudo: false
 language: ruby
+bundler_args: --without development
 rvm:
   - 2.2.4
   - jruby-9.0.5.0

--- a/lib/ruby_dep/travis.rb
+++ b/lib/ruby_dep/travis.rb
@@ -1,5 +1,7 @@
 require 'yaml'
 
+require 'ruby_dep/travis/ruby_version'
+
 module RubyDep
   class Travis
     def version_constraint(filename = '.travis.yml')
@@ -10,13 +12,15 @@ module RubyDep
       lowest = lowest_supported(selected)
 
       ["~> #{lowest[0..1].join('.')}", ">= #{lowest.join('.')}"]
+    rescue RubyVersion::Error => ex
+      abort("RubyDep Error: #{ex.message}")
     end
 
     private
 
     def versions_for_latest_major(versions)
       by_major = versions.map do |x|
-        Gem::Version.new(x).segments[0..2]
+        RubyVersion.new(x).segments[0..2]
       end.group_by(&:first)
 
       last_supported_major = by_major.keys.sort.last

--- a/lib/ruby_dep/travis/ruby_version.rb
+++ b/lib/ruby_dep/travis/ruby_version.rb
@@ -1,0 +1,57 @@
+module RubyDep
+  class Travis
+    class RubyVersion
+      REGEXP = /^
+      (?:
+       (?<engine>ruby|jruby)
+      -)?
+        (?<version>\d+\.\d+\.\d+(?:\.\d+)?)
+      (?:-p\d+)?
+      (?:-clang)?
+      $/x
+
+      class Error < RuntimeError
+        class Unrecognized < Error
+          def initialize(invalid_version_string)
+            @invalid_version_string = invalid_version_string
+          end
+
+          def message
+            "Unrecognized Ruby version: #{@invalid_version_string.inspect}"
+          end
+
+          class JRubyVersion < Unrecognized
+            def message
+              "Unrecognized JRuby version: #{@invalid_version_string.inspect}"
+            end
+          end
+        end
+      end
+
+      def initialize(travis_version_string)
+        ruby_version_string = version_for(travis_version_string)
+        @version = Gem::Version.new(ruby_version_string)
+      end
+
+      def segments
+        @version.segments
+      end
+
+      private
+
+      def version_for(travis_version_string)
+        match = REGEXP.match(travis_version_string)
+        raise Error::Unrecognized, travis_version_string unless match
+        return match[:version] unless match[:engine]
+        return jruby_version(match[:version]) if match[:engine] == 'jruby'
+        match[:version] # if match[:engine] == 'ruby'
+      end
+
+      def jruby_version(version)
+        return '2.2.3' if version == '9.0.5.0'
+        return '2.2.2' if version == '9.0.4.0'
+        raise Error::Unrecognized::JRubyVersion, version
+      end
+    end
+  end
+end

--- a/lib/ruby_dep/warning.rb
+++ b/lib/ruby_dep/warning.rb
@@ -25,18 +25,26 @@ module RubyDep
     private
 
     VERSION_INFO = {
-      '2.3.1' => :unknown,
-      '2.3.0' => :buggy,
-      '2.2.5' => :unknown,
-      '2.2.4' => :buggy,
-      '2.2.0' => :insecure,
-      '2.1.9' => :buggy,
-      '2.0.0' => :insecure
+      'ruby' => {
+        '2.3.1' => :unknown,
+        '2.3.0' => :buggy,
+        '2.2.5' => :unknown,
+        '2.2.4' => :buggy,
+        '2.2.0' => :insecure,
+        '2.1.9' => :buggy,
+        '2.0.0' => :insecure
+      },
+
+      'jruby' => {
+        '2.2.3' => :unknown, # jruby-9.0.5.0
+        '2.2.0' => :insecure
+      }
     }.freeze
 
     def check_ruby
       version = Gem::Version.new(RUBY_VERSION)
-      VERSION_INFO.each do |ruby, status|
+      info = VERSION_INFO[RUBY_ENGINE] || {}
+      info.each do |ruby, status|
         return status if version >= Gem::Version.new(ruby)
       end
       :insecure

--- a/spec/lib/ruby_dep/travis/ruby_version_spec.rb
+++ b/spec/lib/ruby_dep/travis/ruby_version_spec.rb
@@ -1,0 +1,83 @@
+RSpec.describe RubyDep::Travis::RubyVersion do
+  subject { described_class.new(travis_version_string) }
+
+  describe '#initialize' do
+    context 'with an unknown version string' do
+      let(:travis_version_string) { 'ruby-head' }
+      it 'returns the version segments' do
+        expect { subject }.to raise_error(
+          described_class::Error::Unrecognized,
+          /Unrecognized Ruby version: "ruby-head"/
+        )
+      end
+    end
+
+    context 'with an unhandled JRuby version string' do
+      let(:travis_version_string) { 'jruby-9.9.9.9' }
+      it 'returns the version segments' do
+        expect { subject }.to raise_error(
+          described_class::Error::Unrecognized::JRubyVersion,
+          /Unrecognized JRuby version: "9.9.9.9"/
+        )
+      end
+    end
+  end
+
+  describe '#segments' do
+    context 'with a bare version string' do
+      let(:travis_version_string) { '2.2.4' }
+      it 'returns the version segments' do
+        expect(subject.segments).to eq([2, 2, 4])
+      end
+    end
+
+    context 'with a ruby version string' do
+      let(:travis_version_string) { 'ruby-2.2.4' }
+      it 'returns the version segments' do
+        expect(subject.segments).to eq([2, 2, 4])
+      end
+    end
+
+    context 'with a ruby version string' do
+      let(:travis_version_string) { 'ruby-2.2.4' }
+      it 'returns the version segments' do
+        expect(subject.segments).to eq([2, 2, 4])
+      end
+    end
+
+    context 'with JRuby 9.0.4.0' do
+      let(:travis_version_string) { 'jruby-9.0.4.0' }
+      it 'returns the Ruby implementation version segments' do
+        expect(subject.segments).to eq([2, 2, 2])
+      end
+    end
+
+    context 'with JRuby 9.0.5.0' do
+      let(:travis_version_string) { 'jruby-9.0.5.0' }
+      it 'returns the Ruby implementation version segments' do
+        expect(subject.segments).to eq([2, 2, 3])
+      end
+    end
+
+    context 'with a patch-level ruby string' do
+      let(:travis_version_string) { 'ruby-2.0.0-p648' }
+      it 'returns the version segments' do
+        expect(subject.segments).to eq([2, 0, 0])
+      end
+    end
+
+    context 'with a clang ruby string' do
+      let(:travis_version_string) { 'ruby-2.1.10-clang' }
+      it 'returns the version segments' do
+        expect(subject.segments).to eq([2, 1, 10])
+      end
+    end
+
+    context 'with a patch-level clang ruby string' do
+      let(:travis_version_string) { 'ruby-2.1.9-p123-clang' }
+      it 'returns the version segments' do
+        expect(subject.segments).to eq([2, 1, 9])
+      end
+    end
+  end
+end

--- a/spec/lib/ruby_dep/travis_spec.rb
+++ b/spec/lib/ruby_dep/travis_spec.rb
@@ -3,12 +3,64 @@ RSpec.describe RubyDep::Travis do
   describe '#version_constraint' do
     before do
       allow(IO).to receive(:read).with('.travis.yml').and_return(yml)
+      allow(subject).to receive(:abort) do |*args|
+        raise "Unstubbed call to abort(#{args.map(&:inspect).join(',')})"
+      end
     end
 
     context 'with a single ruby version' do
       let(:yml) { YAML.dump('rvm' => %w(2.2.4)) }
       it 'pessimistically locks with intial supported version' do
         expect(subject.version_constraint).to eq(['~> 2.2', '>= 2.2.4'])
+      end
+    end
+
+    context 'with an unknown prefix' do
+      let(:yml) { YAML.dump('rvm' => %w(mruby-head)) }
+      before do
+        allow(subject).to receive(:abort)
+      end
+
+      it 'fails with a useful error' do
+        expect(subject).to receive(:abort)
+          .with(/Unrecognized Ruby version: "mruby-head"/)
+        subject.version_constraint
+      end
+    end
+
+    context 'with a ruby prefix' do
+      let(:yml) { YAML.dump('rvm' => %w(ruby-2.2.4)) }
+      it 'pessimistically locks with intial supported version' do
+        expect(subject.version_constraint).to eq(['~> 2.2', '>= 2.2.4'])
+      end
+    end
+
+    context 'with a jruby prefix' do
+      context 'with version 9.0.5.0' do
+        let(:yml) { YAML.dump('rvm' => %w(jruby-9.0.5.0)) }
+        it 'pessimistically locks with correct intial supported version' do
+          expect(subject.version_constraint).to eq(['~> 2.2', '>= 2.2.3'])
+        end
+      end
+
+      context 'with version 9.0.4.0' do
+        let(:yml) { YAML.dump('rvm' => %w(jruby-9.0.4.0)) }
+        it 'pessimistically locks with correct intial supported version' do
+          expect(subject.version_constraint).to eq(['~> 2.2', '>= 2.2.2'])
+        end
+      end
+
+      context 'with na unknown version 9.0.6.0' do
+        let(:yml) { YAML.dump('rvm' => %w(jruby-9.0.6.0)) }
+        before do
+          allow(subject).to receive(:abort)
+        end
+
+        it 'pessimistically locks with correct intial supported version' do
+          expect(subject).to receive(:abort)
+            .with(/Unrecognized JRuby version: "9.0.6.0"/)
+          subject.version_constraint
+        end
       end
     end
 

--- a/spec/lib/ruby_dep/warning_spec.rb
+++ b/spec/lib/ruby_dep/warning_spec.rb
@@ -4,7 +4,10 @@ RSpec.describe RubyDep::Warning do
   before do
     allow(STDERR).to receive(:puts)
     stub_const('RUBY_VERSION', ruby_version)
+    stub_const('RUBY_ENGINE', ruby_engine)
   end
+
+  let(:ruby_engine) { 'ruby' }
 
   describe '#show_warnings' do
     context 'when silenced' do
@@ -57,6 +60,29 @@ RSpec.describe RubyDep::Warning do
           expect(STDERR).to receive(:puts).with(
             /RubyDep: WARNING: your Ruby has security vulnerabilities!/)
           subject.show_warnings
+        end
+      end
+
+      context 'with JRuby' do
+        context 'when the JRuby is not known to be vulnerable' do
+          let(:ruby_version) { '2.2.3' }
+          let(:ruby_engine) { 'jruby' }
+          it 'does not show warning about vulnerability' do
+            expect(STDERR).to_not receive(:puts)
+            subject.show_warnings
+          end
+        end
+      end
+
+      context 'with an untracked ruby' do
+        context 'when the JRuby is not known to be vulnerable' do
+          let(:ruby_version) { '1.2.3' }
+          let(:ruby_engine) { 'ironruby' }
+          it 'shows warning about vulnerability' do
+            expect(STDERR).to receive(:puts).with(
+              /RubyDep: WARNING: your Ruby has security vulnerabilities!/)
+            subject.show_warnings
+          end
         end
       end
     end


### PR DESCRIPTION
- build on and support jruby-9.0.5.0 (v2.2.3)
- allow/handle JRuby version depedencies
- silence warnings on non-vulnerable JRuby version
