### PR TITLE
allow install on OSX 10.10 (MRI 2.0.0)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,8 @@ sudo: false
 language: ruby
 bundler_args: --without development
 rvm:
+  - 2.0.0
+  - 2.1.9
   - 2.2.4
   - jruby-9.0.5.0
 before_install: gem install bundler -v 1.12.1

--- a/lib/ruby_dep/warning.rb
+++ b/lib/ruby_dep/warning.rb
@@ -1,21 +1,22 @@
 module RubyDep
   class Warning
-    MSG_BUGGY = 'RubyDep: WARNING: your Ruby is outdated/buggy.'\
-      ' Please upgrade.'.freeze
-
-    MSG_INSECURE = 'RubyDep: WARNING: your Ruby has security vulnerabilities!'\
-      ' Please upgrade!'.freeze
+    PREFIX = 'RubyDep: WARNING: '.freeze
+    MSG_BUGGY = 'Your Ruby is outdated/buggy.'.freeze
+    MSG_INSECURE = 'Your Ruby has security vulnerabilities!'.freeze
 
     MSG_HOW_TO_DISABLE = ' (To disable warnings, set'\
       ' RUBY_DEP_GEM_SILENCE_WARNINGS=1)'.freeze
 
+    OPEN_ISSUE_FOR_UNRECOGNIZED = 'If this version is important,'\
+      ' please open an issue at http://github.com/e2/ruby_dep'.freeze
+
     def show_warnings
       return if silenced?
-      case check_ruby
+      case (status = check_ruby)
       when :insecure
-        STDERR.puts MSG_INSECURE + MSG_HOW_TO_DISABLE
+        warn_ruby(MSG_INSECURE, status)
       when :buggy
-        STDERR.puts MSG_BUGGY + MSG_HOW_TO_DISABLE
+        warn_ruby(MSG_BUGGY, status)
       when :unknown
       else
         raise "Unknown problem type: #{problem.inspect}"
@@ -54,8 +55,42 @@ module RubyDep
       (value || '0') !~ /^0|false|no|n$/
     end
 
+    def warn_ruby(msg, status)
+      STDERR.puts PREFIX + msg + MSG_HOW_TO_DISABLE
+      STDERR.puts PREFIX + recommendation(status)
+    end
+
+    def recommendation(status)
+      msg = "Your Ruby is: #{RUBY_VERSION}"
+      return msg + recommendation_for_unknown unless recognized?
+
+      msg += " (#{status})."
+      msg += " Recommendation: install #{recommended(:unknown).join(' or ')}."
+      return msg unless status == :insecure
+
+      msg + " (Or, at least to #{recommended(:buggy).join(' or ')})"
+    end
+
+    def recommended(status)
+      current = Gem::Version.new(RUBY_VERSION)
+      current_ruby_info.select do |key, value|
+        value == status && Gem::Version.new(key) > current
+      end.keys.reverse
+    end
+
     def current_ruby_info
       VERSION_INFO[RUBY_ENGINE] || {}
+    end
+
+    def recognized?
+      current_ruby_info.any?
+    end
+
+    def recommendation_for_unknown
+      format(
+        " '%s' (unrecognized). %s", RUBY_ENGINE,
+        OPEN_ISSUE_FOR_UNRECOGNIZED
+      )
     end
   end
 end

--- a/lib/ruby_dep/warning.rb
+++ b/lib/ruby_dep/warning.rb
@@ -43,8 +43,7 @@ module RubyDep
 
     def check_ruby
       version = Gem::Version.new(RUBY_VERSION)
-      info = VERSION_INFO[RUBY_ENGINE] || {}
-      info.each do |ruby, status|
+      current_ruby_info.each do |ruby, status|
         return status if version >= Gem::Version.new(ruby)
       end
       :insecure
@@ -53,6 +52,10 @@ module RubyDep
     def silenced?
       value = ENV['RUBY_DEP_GEM_SILENCE_WARNINGS']
       (value || '0') !~ /^0|false|no|n$/
+    end
+
+    def current_ruby_info
+      VERSION_INFO[RUBY_ENGINE] || {}
     end
   end
 end

--- a/spec/lib/ruby_dep/warning_spec.rb
+++ b/spec/lib/ruby_dep/warning_spec.rb
@@ -116,6 +116,22 @@ RSpec.describe RubyDep::Warning do
         end
       end
 
+      context 'with JRuby head' do
+        context 'when the JRuby is not known to be vulnerable' do
+          let(:ruby_version) { '2.3.0' }
+          let(:ruby_engine) { 'jruby' }
+          it 'does not show warning about vulnerability' do
+            expect(STDERR).to_not have_received(:puts)
+          end
+
+          it 'does not show a recommendation' do
+            expect(STDERR).to_not have_received(:puts).with(
+              /RubyDep: Your Ruby is:/)
+            expect(STDERR).to_not have_received(:puts).with(/Recommendation:/)
+          end
+        end
+      end
+
       context 'with an untracked ruby' do
         context 'when the Ruby is not listed' do
           let(:ruby_version) { '1.2.3' }

--- a/spec/lib/ruby_dep/warning_spec.rb
+++ b/spec/lib/ruby_dep/warning_spec.rb
@@ -2,14 +2,16 @@ require 'ruby_dep/warning'
 
 RSpec.describe RubyDep::Warning do
   before do
-    allow(STDERR).to receive(:puts)
+    stub_const('STDERR', instance_double(IO))
     stub_const('RUBY_VERSION', ruby_version)
     stub_const('RUBY_ENGINE', ruby_engine)
+    allow(STDERR).to receive(:puts)
   end
 
   let(:ruby_engine) { 'ruby' }
 
   describe '#show_warnings' do
+    before { subject.show_warnings }
     context 'when silenced' do
       around do |example|
         old = ENV['RUBY_DEP_GEM_SILENCE_WARNINGS']
@@ -21,8 +23,7 @@ RSpec.describe RubyDep::Warning do
       context 'with any outdated Ruby' do
         let(:ruby_version) { '1.9.3' }
         it 'does not show warning' do
-          expect(STDERR).to_not receive(:puts)
-          subject.show_warnings
+          expect(STDERR).to_not have_received(:puts)
         end
       end
     end
@@ -31,35 +32,39 @@ RSpec.describe RubyDep::Warning do
       context 'with an up-to-date Ruby' do
         let(:ruby_version) { '2.3.1' }
         it 'does not show warning' do
-          expect(STDERR).to_not receive(:puts)
-          subject.show_warnings
+          expect(STDERR).to_not have_received(:puts)
         end
       end
 
       context 'with a secure but buggy Ruby' do
         let(:ruby_version) { '2.2.4' }
         it 'shows warning about bugs' do
-          expect(STDERR).to receive(:puts).with(
+          expect(STDERR).to have_received(:puts).with(
             %r{RubyDep: WARNING: your Ruby is outdated\/buggy.})
-          subject.show_warnings
         end
       end
 
       context 'with an insecure Ruby' do
         let(:ruby_version) { '2.2.3' }
         it 'shows warning about vulnerability' do
-          expect(STDERR).to receive(:puts).with(
+          expect(STDERR).to have_received(:puts).with(
             /RubyDep: WARNING: your Ruby has security vulnerabilities!/)
-          subject.show_warnings
+        end
+      end
+
+      context 'with an insecure base Ruby' do
+        let(:ruby_version) { '2.2.3' }
+        it 'shows warning about vulnerability' do
+          expect(STDERR).to have_received(:puts).with(
+            /RubyDep: WARNING: your Ruby has security vulnerabilities!/)
         end
       end
 
       context 'with an unsupported Ruby' do
         let(:ruby_version) { '1.9.3' }
         it 'shows warning about vulnerability' do
-          expect(STDERR).to receive(:puts).with(
+          expect(STDERR).to have_received(:puts).with(
             /RubyDep: WARNING: your Ruby has security vulnerabilities!/)
-          subject.show_warnings
         end
       end
 
@@ -68,8 +73,7 @@ RSpec.describe RubyDep::Warning do
           let(:ruby_version) { '2.2.3' }
           let(:ruby_engine) { 'jruby' }
           it 'does not show warning about vulnerability' do
-            expect(STDERR).to_not receive(:puts)
-            subject.show_warnings
+            expect(STDERR).to_not have_received(:puts)
           end
         end
       end
@@ -79,9 +83,8 @@ RSpec.describe RubyDep::Warning do
           let(:ruby_version) { '1.2.3' }
           let(:ruby_engine) { 'ironruby' }
           it 'shows warning about vulnerability' do
-            expect(STDERR).to receive(:puts).with(
+            expect(STDERR).to have_received(:puts).with(
               /RubyDep: WARNING: your Ruby has security vulnerabilities!/)
-            subject.show_warnings
           end
         end
       end

--- a/spec/lib/ruby_dep/warning_spec.rb
+++ b/spec/lib/ruby_dep/warning_spec.rb
@@ -53,7 +53,7 @@ RSpec.describe RubyDep::Warning do
       end
 
       context 'with an insecure base Ruby' do
-        let(:ruby_version) { '2.2.3' }
+        let(:ruby_version) { '2.2.0' }
         it 'shows warning about vulnerability' do
           expect(STDERR).to have_received(:puts).with(
             /RubyDep: WARNING: your Ruby has security vulnerabilities!/)
@@ -79,7 +79,7 @@ RSpec.describe RubyDep::Warning do
       end
 
       context 'with an untracked ruby' do
-        context 'when the JRuby is not known to be vulnerable' do
+        context 'when the Ruby is not listed' do
           let(:ruby_version) { '1.2.3' }
           let(:ruby_engine) { 'ironruby' }
           it 'shows warning about vulnerability' do

--- a/spec/lib/ruby_dep/warning_spec.rb
+++ b/spec/lib/ruby_dep/warning_spec.rb
@@ -10,6 +10,10 @@ RSpec.describe RubyDep::Warning do
 
   let(:ruby_engine) { 'ruby' }
 
+  def rquote(str)
+    Regexp.new(Regexp.quote(str))
+  end
+
   describe '#show_warnings' do
     before { subject.show_warnings }
     context 'when silenced' do
@@ -40,7 +44,14 @@ RSpec.describe RubyDep::Warning do
         let(:ruby_version) { '2.2.4' }
         it 'shows warning about bugs' do
           expect(STDERR).to have_received(:puts).with(
-            %r{RubyDep: WARNING: your Ruby is outdated\/buggy.})
+            %r{Your Ruby is outdated\/buggy.})
+        end
+
+        it 'shows recommended action' do
+          expected = rquote(
+            'Your Ruby is: 2.2.4 (buggy). Recommendation: install'\
+            ' 2.2.5 or 2.3.1')
+          expect(STDERR).to have_received(:puts).with(expected)
         end
       end
 
@@ -48,7 +59,14 @@ RSpec.describe RubyDep::Warning do
         let(:ruby_version) { '2.2.3' }
         it 'shows warning about vulnerability' do
           expect(STDERR).to have_received(:puts).with(
-            /RubyDep: WARNING: your Ruby has security vulnerabilities!/)
+            /Your Ruby has security vulnerabilities!/)
+        end
+
+        it 'shows recommended action' do
+          expected = rquote(
+            'Your Ruby is: 2.2.3 (insecure). Recommendation:'\
+            ' install 2.2.5 or 2.3.1. (Or, at least to 2.2.4 or 2.3.0)')
+          expect(STDERR).to have_received(:puts).with(expected)
         end
       end
 
@@ -56,7 +74,14 @@ RSpec.describe RubyDep::Warning do
         let(:ruby_version) { '2.2.0' }
         it 'shows warning about vulnerability' do
           expect(STDERR).to have_received(:puts).with(
-            /RubyDep: WARNING: your Ruby has security vulnerabilities!/)
+            /Your Ruby has security vulnerabilities!/)
+        end
+
+        it 'shows recommended action' do
+          expected = rquote(
+            'Your Ruby is: 2.2.0 (insecure). Recommendation: install 2.2.5'\
+            ' or 2.3.1. (Or, at least to 2.2.4 or 2.3.0)')
+          expect(STDERR).to have_received(:puts).with(expected)
         end
       end
 
@@ -64,7 +89,14 @@ RSpec.describe RubyDep::Warning do
         let(:ruby_version) { '1.9.3' }
         it 'shows warning about vulnerability' do
           expect(STDERR).to have_received(:puts).with(
-            /RubyDep: WARNING: your Ruby has security vulnerabilities!/)
+            /Your Ruby has security vulnerabilities!/)
+        end
+
+        it 'shows recommended action' do
+          expected = rquote(
+            'Your Ruby is: 1.9.3 (insecure). Recommendation: install 2.2.5'\
+            ' or 2.3.1. (Or, at least to 2.1.9 or 2.2.4 or 2.3.0)')
+          expect(STDERR).to have_received(:puts).with(expected)
         end
       end
 
@@ -75,6 +107,12 @@ RSpec.describe RubyDep::Warning do
           it 'does not show warning about vulnerability' do
             expect(STDERR).to_not have_received(:puts)
           end
+
+          it 'does not show a recommendation' do
+            expect(STDERR).to_not have_received(:puts).with(
+              /RubyDep: Your Ruby is:/)
+            expect(STDERR).to_not have_received(:puts).with(/Recommendation:/)
+          end
         end
       end
 
@@ -84,7 +122,15 @@ RSpec.describe RubyDep::Warning do
           let(:ruby_engine) { 'ironruby' }
           it 'shows warning about vulnerability' do
             expect(STDERR).to have_received(:puts).with(
-              /RubyDep: WARNING: your Ruby has security vulnerabilities!/)
+              /Your Ruby has security vulnerabilities!/)
+          end
+
+          it 'shows recommended action' do
+            expected = rquote(
+              "Your Ruby is: 1.2.3 'ironruby' (unrecognized). If this"\
+              ' version is important, please open an issue at'\
+              ' http://github.com/e2/ruby_dep')
+            expect(STDERR).to have_received(:puts).with(expected)
           end
         end
       end


### PR DESCRIPTION
Upgrading OSX is not free and Apple has no financial incentive in backporting updated Rubies to older OSX releases. And buying a new OSX+hardware is costly. And given 10.10 has been around for some time, it might take a long while (and lots of disk space) to upgrade to Ruby 2.3.

So this patch temporarily allows installing ruby_dep with Ruby 2.0.0.

At least users get a warning though (if a dependency shows them). One they can turn off.
