### PR TITLE
add 2.3.0 support (no vulnerabilities, just bugs)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ rvm:
   - 2.1.9
   - 2.2.4
   - 2.2.5
+  - 2.3.0
   - 2.3.1
   - jruby-9.0.5.0
 before_install: gem install bundler -v 1.12.1


### PR DESCRIPTION
Not necessary - by the time 2.2 will be EOL, upgrading to 2.3.1 (or later should be trivial).
