### PR TITLE
drop support for Ruby < 2.2.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,12 +2,8 @@ sudo: false
 language: ruby
 bundler_args: --without development
 rvm:
-  - 2.0.0
-  - 2.1.9
-  - 2.2.4
   - 2.2.5
   - 2.3.1
-  - jruby-9.0.5.0
   - jruby-9.1.2.0
 before_install: gem install bundler -v 1.12.1
 cache: bundler

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,5 +5,5 @@ rvm:
   - 2.2.5
   - 2.3.1
   - jruby-9.1.2.0
-before_install: gem install bundler -v 1.12.1
+before_install: gem install bundler -v 1.12.5
 cache: bundler


### PR DESCRIPTION
Reasons:
- 2.1 not supported anymore
- people who need older version can lock anyway
- to avoid forcing that support on other gems
- to reduce Travis build time on all related gems
- new fixed Ruby versions available
- Ruby 2.4 comming up already
