### PR TITLE
Add require of tmpdir stdlib

### DIFF
--- a/lib/ruby_dep/travis.rb
+++ b/lib/ruby_dep/travis.rb
@@ -1,3 +1,4 @@
+require 'tmpdir'
 require 'yaml'
 
 require 'ruby_dep/travis/ruby_version'


### PR DESCRIPTION
In order to pass the test suite, I added this `require` line.

(I ran the tests on Ruby 2.4.0. [Docs for tmpdir](http://ruby-doc.org/stdlib-2.4.0/libdoc/tmpdir/rdoc/Dir.html).)