### PR TITLE
RuboCop auto-lint

### DIFF
--- a/lib/ruby_dep/logger.rb
+++ b/lib/ruby_dep/logger.rb
@@ -11,7 +11,7 @@ module RubyDep
 
   def self.stderr_logger
     ::Logger.new(STDERR).tap do |logger|
-      logger.formatter = proc { |_,_,_,msg| "#{msg}\n" }
+      logger.formatter = proc { |_, _, _, msg| "#{msg}\n" }
     end
   end
 
@@ -34,7 +34,7 @@ module RubyDep
     def initialize(device, prefix)
       @device = device
       @prefix = prefix
-      ::RubyDep.logger.warn("The RubyDep::Logger class is deprecated")
+      ::RubyDep.logger.warn('The RubyDep::Logger class is deprecated')
     end
 
     def warning(msg)

--- a/spec/acceptance/fixtures/stdout_logger.rb
+++ b/spec/acceptance/fixtures/stdout_logger.rb
@@ -10,7 +10,7 @@ module RubyDep
 end
 
 RubyDep.logger = Logger.new(STDOUT).tap do |logger|
-  logger.formatter = proc do |severity,_,_,msg|
+  logger.formatter = proc do |severity, _, _, _msg|
     "#{severity};"
   end
 end

--- a/spec/acceptance/warnings_spec.rb
+++ b/spec/acceptance/warnings_spec.rb
@@ -71,7 +71,7 @@ RSpec.describe 'warnings' do
       let!(:spec) { 'stdout_logger.rb' }
       let(:code) do
         "o=`#{subcmd}`;"\
-          "expected = \"WARN;INFO;INFO;\";" \
+          'expected = "WARN;INFO;INFO;";' \
           "raise \"Unexpected output: \#{o.inspect}\" unless o == expected"
       end
       it 'uses the given logger' do

--- a/spec/lib/ruby_dep/logger_spec.rb
+++ b/spec/lib/ruby_dep/logger_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe RubyDep do
 
       it 'sets up a simple formatter' do
         expect(stderr_logger).to receive(:formatter=) do |callback|
-          expect( callback.call('a', 'b', 'c', 'd')).to eq("d\n")
+          expect(callback.call('a', 'b', 'c', 'd')).to eq("d\n")
         end
         described_class.logger
       end


### PR DESCRIPTION
This PR makes the project pass RuboCop's linting.

It was done using `--auto-correct`.