### PR TITLE
Add TruffleRuby to the list of known Ruby versions

### DIFF
--- a/lib/ruby_dep/ruby_version.rb
+++ b/lib/ruby_dep/ruby_version.rb
@@ -39,7 +39,11 @@ module RubyDep
         '2.3.0' => :unknown, # jruby-9.1.2.0, jruby-9.1.0.0
         '2.2.3' => :buggy, # jruby-9.0.5.0
         '2.2.0' => :insecure
-      }
+      },
+
+      'truffleruby' => {
+        '2.4.4' => :unknown,
+      },
     }.freeze
 
     def info

--- a/spec/lib/ruby_dep/ruby_version_spec.rb
+++ b/spec/lib/ruby_dep/ruby_version_spec.rb
@@ -27,6 +27,16 @@ RSpec.describe RubyDep::RubyVersion do
       subject { described_class.new('2.3.0', 'jruby') }
       specify { expect(subject).to be_recognized }
     end
+
+    context 'with truffleruby 1.0.0-rc2' do
+      subject { described_class.new('2.4.4', 'truffleruby') }
+      specify { expect(subject).to be_recognized }
+    end
+
+    context 'with a recent truffleruby' do
+      subject { described_class.new('2.6.1', 'truffleruby') }
+      specify { expect(subject).to be_recognized }
+    end
   end
 
   describe '#status' do
@@ -57,6 +67,16 @@ RSpec.describe RubyDep::RubyVersion do
 
     context 'with a future ruby' do
       subject { described_class.new('9.8.7', 'ruby') }
+      specify { expect(subject.status).to eq(:unknown) }
+    end
+
+    context 'with truffleruby 1.0.0-rc2' do
+      subject { described_class.new('2.4.4', 'truffleruby') }
+      specify { expect(subject.status).to eq(:unknown) }
+    end
+
+    context 'with a recent truffleruby' do
+      subject { described_class.new('2.6.1', 'truffleruby') }
       specify { expect(subject.status).to eq(:unknown) }
     end
   end


### PR DESCRIPTION
This is needed so `ruby_dep` does not warn when using e.g. Rails.

The first TruffleRuby release installable by RVM/ruby-build/ruby-install is `1.0.0-rc2`, so I'm using that as the oldest version supported.